### PR TITLE
add non-GCC support to compile.c and potion.c

### DIFF
--- a/core/internal.h
+++ b/core/internal.h
@@ -37,7 +37,7 @@ typedef unsigned char u8;
   (N)->siz = sizeof(*(N)->ptr) * S; \
   (N)->len = 0
 
-#define PN_FLEX_NEEDS(X, N, V, T, S) ({ \
+#define PN_FLEX_NEEDS(X, N, V, T, S) do { \
   PN_SIZE capa = (N)->siz / sizeof(*(N)->ptr); \
   if (capa < (N)->len + X) { \
     while (capa < (N)->len + X) \
@@ -46,24 +46,24 @@ typedef unsigned char u8;
     PN_REALLOC(N, V, T, capa); \
     (N)->siz = capa; \
   } \
-})
+} while(0);
 
-#define PN_ATOI(X,N,B) ({ \
-  char *Ap = X; \
-  long Ai = 0; \
-  size_t Al = N; \
-  while (Al--) { \
-    if ((*Ap >= '0') && (*Ap <= '9')) \
-      Ai = (Ai * B) + (*Ap - '0'); \
-    else if ((*Ap >= 'A') && (*Ap <= 'F')) \
-      Ai = (Ai * B) + ((*Ap - 'A') + 10); \
-    else if ((*Ap >= 'a') && (*Ap <= 'f')) \
-      Ai = (Ai * B) + ((*Ap - 'a') + 10); \
-    else break; \
-    Ap++; \
-  } \
-  Ai; \
-})
+
+#define PN_ATOI(X,N,B) potion_atoi(X, N, B)
+inline static long potion_atoi(char *Ap, size_t Al, const long B) {
+  long Ai = 0;
+  while (Al--) {
+    if ((*Ap >= '0') && (*Ap <= '9'))
+      Ai = (Ai * B) + (*Ap - '0');
+    else if ((*Ap >= 'A') && (*Ap <= 'F'))
+      Ai = (Ai * B) + ((*Ap - 'A') + 10);
+    else if ((*Ap >= 'a') && (*Ap <= 'f'))
+      Ai = (Ai * B) + ((*Ap - 'a') + 10);
+    else break;
+    Ap++;
+  }
+  return Ai;
+}
 
 /// .pnb binary dump header
 struct PNBHeader {


### PR DESCRIPTION
This is generating lots of test fails, IDK why. "test/classes/sub.pn: expected <(7, 52, 9, 81)>, but got <(7, 52, nil, nil)>" is a known failure before this patch, but "expected <105>, but got <>" stuff is new. Cygwin make test example below

```
--------------------------------------------------------------------------------------------------------------
running potion VM tests
....
test/classes/sub.pn: expected <(7, 52, 9, 81)>, but got <(7, 52, nil, nil)>
..............
test/flow/except.pn: expected <TRY 1
TRY ERROR!
RESUMING
SUCCESS
TRY 2
SUCCESS
nil>, but got <TRY 1
TRY 2
SUCCESS
nil>
..............................................................
running potion compiler tests

test/classes/creature.pn: expected <((45, 65, 27, 89), (10, 44, 44, 4), 3)>, but got <>

test/classes/def.pn: expected <203>, but got <>

test/classes/meta.pn: expected <1677>, but got <>

test/classes/monkey.pn: expected <159>, but got <>

test/classes/sub.pn: expected <(7, 52, 9, 81)>, but got <>

test/closures/arg0.pn: expected <no arguments and highly sparse>, but got <>

test/closures/default.pn: expected <(1, 0, 1, 1, function(x:=0,y:=1), 2)>, but got <>

test/closures/inspect.pn: expected <function(x,y)>, but got <>

test/closures/long.pn: expected <105>, but got <>

test/closures/named.pn: expected <(1, -77, 97, XXX, Kiriku)>, but got <>

test/closures/nested.pn: expected <60>, but got <>

test/closures/passing.pn: expected <58>, but got <>

test/closures/upvals.pn: expected <(function(), 17, 45, 67, 23, true, 16, (nil, nil), (b=2))>, but got <>

test/data/grammar.pn: expected <[grammar [digit <- n:[0-9] { n number }, value <- d:digit+ | '(' e:expr ')' { d or e }, expr <- l:value op:[*/] r:value
  {
    if (op == '*'): l * r. else: l / r.
  }, main <- expr]]>, but got <>

test/data/html.pn: expected <<html><body(margin=0)><p>SUPERIOR!</p><em></em><strong(padding=2)></strong></body></html>nil>, but got <>

test/data/string.pn: expected <([potion 0.0 (date=2009-06-16)], [app [stack [button Mice, button Eagles, button Quail]]])>, but got <>

test/flow/break.pn: expected <(10, 10, 10)>, but got <>

test/flow/callcc.pn: expected <Ringo
Max
Ron
nil>, but got <>

test/flow/continue.pn: expected <(0, (20, 10), (10, 10))>, but got <>

test/flow/except.pn: expected <TRY 1
TRY ERROR!
RESUMING
SUCCESS
TRY 2
SUCCESS
nil>, but got <>

test/flow/if.pn: expected <(14, 16, 12, Lobby, 10)>, but got <>

test/flow/mixed.pn: expected <Seth>, but got <>

test/flow/return.pn: expected <(1, 2, 3, nil, nil)>, but got <>

test/flow/while.pn: expected <4>, but got <>

test/lists/alloc.pn: expected <(nil, 1, nil)>, but got <>

test/lists/at.pn: expected <(germans, nil, bottles, exists, bottles)>, but got <>

test/lists/map.pn: expected <(1, 2, 3)>, but got <>
```
